### PR TITLE
Misspelled method name and fix for _objects.clear()

### DIFF
--- a/gury.js
+++ b/gury.js
@@ -114,7 +114,7 @@ window.$g = window.Gury = (function(window, jQuery) {
     
     this.remove = function(key) {
       if (isDefined(key)) {
-        var h = hask(key);
+        var h = hash(key);
         delete table[h];
         length--;
       }

--- a/gury.js
+++ b/gury.js
@@ -174,7 +174,7 @@ window.$g = window.Gury = (function(window, jQuery) {
     this.each = function(closure) {
       if (ordered) {
         for (var i = 0; i < ordered.length; i++) {
-          closure(ordered[i], i);
+          closure.call(this, ordered[i], i);
         }
       }
       else {


### PR DESCRIPTION
In .each call the closure using Function.call(this, ...) rather than closure(...);
Changed hask -> hash
