### PR TITLE
Console.log in demo four

### DIFF
--- a/demos/demo4.html
+++ b/demos/demo4.html
@@ -32,7 +32,6 @@
     <script type="text/javascript" charset="utf-8">
       $(function() {
         var gury = $g();
-        console.log(gury);
         
         var board;
         var colors = ["#a00", "#0a0", "#00a"];


### PR DESCRIPTION
There was a console.log statement in the fourth demo that threw an error in Firefox. This commit removes it.
